### PR TITLE
Sign proxied requests.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,7 @@ Install autopilot:
 Deploy:
 
     cf zero-downtime-push fec-proxy -f manifest.yml
+
+## Notes
+
+**fec-proxy** uses the openresty nginx bundle for extras like HMAC signing. The bundled `nginx.tgz` file was built under trusty64 using vagrant.

--- a/manifest.yml
+++ b/manifest.yml
@@ -3,6 +3,8 @@ domain: 18f.gov
 buildpack: "https://github.com/jmcarp/staticfile-buildpack.git"
 applications:
   - name: fec-proxy
+services:
+  - fec-creds-dev
 env:
   PROXIES: |
     {

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,5 +1,6 @@
 ---
 domain: 18f.gov
+buildpack: "https://github.com/jmcarp/staticfile-buildpack.git"
 applications:
   - name: fec-proxy
 env:

--- a/nginx.conf
+++ b/nginx.conf
@@ -35,12 +35,25 @@ http {
 
     <% require 'json' %>
     <% proxies = JSON.parse(ENV["PROXIES"] || "{}") %>
+    <%
+      secret = ENV["HMAC_SECRET"] ||
+        (JSON.parse(ENV["VCAP_SERVICES"])["user-provided"] || []).map { |service|
+          service["credentials"]["HMAC_SECRET"]
+        }.find { |secret|
+          secret
+        }
+    %>
 
     <% proxies.each do |path, route| %>
       location <%= path %> {
         resolver 8.8.8.8;
         set $backend "<%= route %>";
         proxy_pass $backend;
+        <% if secret %>
+        set_hmac_sha1 $signature "<%= secret %>" "$http_content_length\n$http_content_md5\n$http_content_type\n$http_date";
+        set_encode_base64 $signature $signature;
+        proxy_set_header X-Signature $signature;
+        <% end %>
         proxy_set_header X-Forwarded-Host $host;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Script-Name <%= path %>;

--- a/nginx.conf
+++ b/nginx.conf
@@ -36,12 +36,23 @@ http {
     <% require 'json' %>
     <% proxies = JSON.parse(ENV["PROXIES"] || "{}") %>
     <%
-      secret = ENV["HMAC_SECRET"] ||
-        (JSON.parse(ENV["VCAP_SERVICES"])["user-provided"] || []).map { |service|
-          service["credentials"]["HMAC_SECRET"]
-        }.find { |secret|
-          secret
-        }
+      def getenv(key)
+        services = JSON.parse(ENV["VCAP_SERVICES"] || "{}")["user-provided"] || []
+        ENV[key] ||
+          services.map { |service|
+            service["credentials"][key]
+          }.find { |value|
+            value
+          }
+      end
+      def string_to_sign(headers)
+        keys = ["$request_method"]
+        keys.concat(headers.map { |header| "$http_#{header}" })
+        keys.concat(["$request_uri", "$request_body"])
+        return keys.join("\\n")
+      end
+      secret = getenv("HMAC_SECRET")
+      headers = (getenv("HMAC_HEADERS") || "").split(",")
     %>
 
     <% proxies.each do |path, route| %>
@@ -49,14 +60,15 @@ http {
         resolver 8.8.8.8;
         set $backend "<%= route %>";
         proxy_pass $backend;
-        <% if secret %>
-        set_hmac_sha1 $signature "<%= secret %>" "$http_content_length\n$http_content_md5\n$http_content_type\n$http_date";
-        set_encode_base64 $signature $signature;
-        proxy_set_header X-Signature $signature;
-        <% end %>
         proxy_set_header X-Forwarded-Host $host;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Script-Name <%= path %>;
+
+        <% if secret %>
+        set_hmac_sha1 $signature "<%= secret %>" "<%= string_to_sign(headers) %>";
+        set_encode_base64 $signature $signature;
+        proxy_set_header X-Signature "sha1 $signature";
+        <% end %>
       }
     <% end %>
   }


### PR DESCRIPTION
If `HMAC_SECRET` is found in the environment or in a user-provided service, HMAC-sign the request headers and pass the signature to the proxied application.

Flagging @dhcole @mbland and/or @ozzyjohnson for review, time permitting. Note: as suggested by @dhcole, this patch uses a fork of the staticfile buildpack that allows for custom nginx binaries--in this case, openresty.