### PR TITLE
Add a route for eregs

### DIFF
--- a/manifest_base.yml
+++ b/manifest_base.yml
@@ -8,5 +8,6 @@ env:
   PROXIES: |
     {
       "/": "https://fec-dev-cms.18f.gov",
-      "/data": "https://fec-dev-web.18f.gov"
+      "/data": "https://fec-dev-web.18f.gov",
+      "/regulations": "https://fec-dev-eregs.18f.gov"
     }

--- a/manifest_dev.yml
+++ b/manifest_dev.yml
@@ -7,5 +7,6 @@ env:
   PROXIES: |
     {
       "/": "https://fec-dev-cms.18f.gov",
-      "/data": "https://fec-dev-web.18f.gov"
+      "/data": "https://fec-dev-web.18f.gov",
+      "/regulations": "https://fec-dev-eregs.18f.gov"
     }

--- a/manifest_feature.yml
+++ b/manifest_feature.yml
@@ -7,5 +7,6 @@ env:
   PROXIES: |
     {
       "/": "https://fec-feature-cms.18f.gov",
-      "/data": "https://fec-feature-web.18f.gov"
+      "/data": "https://fec-feature-web.18f.gov",
+      "/regulations": "https://fec-feature-eregs.18f.gov"
     }

--- a/manifest_prod.yml
+++ b/manifest_prod.yml
@@ -8,5 +8,6 @@ env:
   PROXIES: |
     {
       "/": "https://fec-prod-cms.18f.gov",
-      "/data": "https://fec-prod-web.18f.gov"
+      "/data": "https://fec-prod-web.18f.gov",
+      "/regulations": "https://fec-prod-eregs.18f.gov"
     }

--- a/manifest_stage.yml
+++ b/manifest_stage.yml
@@ -7,5 +7,6 @@ env:
   PROXIES: |
     {
       "/": "https://fec-stage-cms.18f.gov",
-      "/data": "https://fec-stage-web.18f.gov"
+      "/data": "https://fec-stage-web.18f.gov",
+      "/regulations": "https://fec-stage-eregs.18f.gov"
     }


### PR DESCRIPTION
As per https://github.com/18F/fec-eregs/issues/89

Not all the apps are launched yet in cloud.gov, so some of these URLs might 404 or error.