### PR TITLE
Feature/content buckets

### DIFF
--- a/manifest_base.yml
+++ b/manifest_base.yml
@@ -11,3 +11,4 @@ env:
       "/data": "https://fec-dev-web.18f.gov",
       "/regulations": "https://fec-dev-eregs.18f.gov"
     }
+  S3_BUCKET_URL: "https://cg-449d4df6-4b9e-4539-891f-363302ca5907.s3-us-gov-west-1.amazonaws.com"

--- a/manifest_dev.yml
+++ b/manifest_dev.yml
@@ -10,3 +10,4 @@ env:
       "/data": "https://fec-dev-web.18f.gov",
       "/regulations": "https://fec-dev-eregs.18f.gov"
     }
+  S3_BUCKET_URL: "https://cg-449d4df6-4b9e-4539-891f-363302ca5907.s3-us-gov-west-1.amazonaws.com"

--- a/manifest_prod.yml
+++ b/manifest_prod.yml
@@ -12,3 +12,4 @@ env:
       "/data": "https://fec-prod-web.18f.gov",
       "/regulations": "https://fec-prod-eregs.18f.gov"
     }
+  S3_BUCKET_URL: "https://cg-47928592-406c-4536-8234-99b896e8d57d.s3-us-gov-west-1.amazonaws.com"

--- a/manifest_stage.yml
+++ b/manifest_stage.yml
@@ -10,3 +10,4 @@ env:
       "/data": "https://fec-stage-web.18f.gov",
       "/regulations": "https://fec-stage-eregs.18f.gov"
     }
+  S3_BUCKET_URL: "https://cg-ca811ea5-b3e6-4792-ac55-2edf11f151ca.s3-us-gov-west-1.amazonaws.com"

--- a/nginx.conf
+++ b/nginx.conf
@@ -85,7 +85,7 @@ http {
     location ~ /resources-stage/(.*) {
       resolver 8.8.8.8;
       proxy_pass_request_headers off;
-      proxy_pass https://g-ca811ea5-b3e6-4792-ac55-2edf11f151ca.s3-us-gov-west-1.amazonaws.com/$1;
+      proxy_pass https://cg-ca811ea5-b3e6-4792-ac55-2edf11f151ca.s3-us-gov-west-1.amazonaws.com/$1;
     }
   }
 }

--- a/nginx.conf
+++ b/nginx.conf
@@ -75,17 +75,7 @@ http {
     location ~ /resources/(.*) {
       resolver 8.8.8.8;
       proxy_pass_request_headers off;
-      proxy_pass https://cg-47928592-406c-4536-8234-99b896e8d57d.s3-us-gov-west-1.amazonaws.com/$1;
-    }
-    location ~ /resources-dev/(.*) {
-      resolver 8.8.8.8;
-      proxy_pass_request_headers off;
-      proxy_pass https://cg-449d4df6-4b9e-4539-891f-363302ca5907.s3-us-gov-west-1.amazonaws.com/$1;
-    }
-    location ~ /resources-stage/(.*) {
-      resolver 8.8.8.8;
-      proxy_pass_request_headers off;
-      proxy_pass https://cg-ca811ea5-b3e6-4792-ac55-2edf11f151ca.s3-us-gov-west-1.amazonaws.com/$1;
+      proxy_pass ENV["S3_BUCKET_URL"]/$1;
     }
   }
 }

--- a/nginx.conf
+++ b/nginx.conf
@@ -77,5 +77,15 @@ http {
       proxy_pass_request_headers off;
       proxy_pass https://cg-47928592-406c-4536-8234-99b896e8d57d.s3-us-gov-west-1.amazonaws.com/$1;
     }
+    location ~ /resources-dev/(.*) {
+      resolver 8.8.8.8;
+      proxy_pass_request_headers off;
+      proxy_pass https://cg-449d4df6-4b9e-4539-891f-363302ca5907.s3-us-gov-west-1.amazonaws.com/$1;
+    }
+    location ~ /resources-stage/(.*) {
+      resolver 8.8.8.8;
+      proxy_pass_request_headers off;
+      proxy_pass https://g-ca811ea5-b3e6-4792-ac55-2edf11f151ca.s3-us-gov-west-1.amazonaws.com/$1;
+    }
   }
 }

--- a/nginx.conf
+++ b/nginx.conf
@@ -75,7 +75,7 @@ http {
     location ~ /resources/(.*) {
       resolver 8.8.8.8;
       proxy_pass_request_headers off;
-      proxy_pass ENV["S3_BUCKET_URL"]/$1;
+      proxy_pass <%= ENV["S3_BUCKET_URL"] %>/$1;
     }
   }
 }


### PR DESCRIPTION
This will work to get wagtail assets going, but their are trade-offs. 
For some reason, this was not working with dynamically generating the
redirects like it does for the apps. So, I gave each bucket a unique
name. 

Urls will be different across dev stage and prod. So, data dumps
across the environments might work oddly, but that might have happened
anyway. you will also be able to get to all buckets from each url, I
don't think that it will cause problems, it's just weird.
feature/content-buckets

deployed this to dev and staging with a test file:
* `dev`: https://fec-proxy.18f.gov/resources/example.txt
* `stage`: https://fec-stage-proxy.18f.gov/resources/example.txt

Thanks to @jmcarp for helping on this- it was really a life saver!

---

**UPDATE FROM @ccostino**

Thanks to more help from @jmcarp, we now have this ready to go!  The S3 buckets are now configurable via environment variables set in the manifest files and there is now a single new location rewrite rule for `resources/`.  The bucket associated with the environment is what will be redirected to under the hood, e.g., the `dev` S3 bucket is what is referenced for the `dev` instances of the proxy app.

This means that we now have just the one URL and only one bucket is accessible per environment (the one associated with the environment).  In the future, when we make the GovCloud migration within our cloud.gov spaces, we'll want to switch this to the `VCAP_SERVICES`, but for now this will meet our needs.

Thank you again for all of your help with this, @jmcarp, and thanks to @LindsayYoung for spearheading this effort and getting it done!