### PR TITLE
Updated FECIG Redirect

### DIFF
--- a/redirects-transition.conf
+++ b/redirects-transition.conf
@@ -35,7 +35,6 @@ rewrite ^/directives/CommissionDirectives.shtml https://beta.fec.gov/about/leade
 rewrite ^/members/?$ https://beta.fec.gov/about/leadership-and-structure/commissioners/ redirect;
 rewrite ^/info/mission.shtml https://beta.fec.gov/about/mission-and-history/ redirect;
 rewrite ^/pages/anreport.shtml https://beta.fec.gov/about/reports-about-fec/annual-and-anniversary-reports/ redirect;
-rewrite ^/fecig/fecig.shtml https://beta.fec.gov/about/reports-about-fec/oig-reports/ redirect;
 rewrite ^/pages/procure/procure.shtml https://beta.fec.gov/about/reports-about-fec/procurement-and-contracting/ redirect;
 rewrite ^/pages/budget/budget.shtml https://beta.fec.gov/about/reports-about-fec/strategy-budget-and-performance/ redirect;
 rewrite ^/pages/budget/budget.shtml https://beta.fec.gov/about/reports-about-fec/strategy-budget-and-performance/ redirect;

--- a/redirects-www.conf
+++ b/redirects-www.conf
@@ -96,7 +96,7 @@ rewrite ^/ans/answers_party.shtml http://transition.fec.gov/ans/answers_party.sh
 rewrite ^/ans/answers_public_funding.shtml http://transition.fec.gov/ans/answers_public_funding.shtml redirect;
 rewrite ^/pages/contact.shtml https://www.fec.gov/contact-us/ redirect;
 rewrite ^/directives/CommissionDirectives.shtml https://www.fec.gov/about/leadership-and-structure/#commission-directives-and-policy redirect;
-rewrite ^/fecig/fecig.shtml https://www.fec.gov/about/reports-about-fec/oig-reports/ redirect;
+rewrite ^/fecig/fecig.shtml https://transition.fec.gov/fecig/fecig.shtml redirect;
 rewrite ^/pages/budget/budget.shtml https://www.fec.gov/about/reports-about-fec/strategy-budget-and-performance/ redirect;
 rewrite ^/pages/procure/procure.shtml https://www.fec.gov/about/reports-about-fec/procurement-and-contracting/ redirect;
 rewrite ^/pages/anreport.shtml https://www.fec.gov/about/reports-about-fec/annual-and-anniversary-reports/ redirect;


### PR DESCRIPTION
Changed FECIG redirect so that users are redirected to the transition site instead of being redirected to new site.