### PR TITLE
Redirect fixes

### DIFF
--- a/redirects-transition.conf
+++ b/redirects-transition.conf
@@ -40,7 +40,7 @@ rewrite ^/pages/budget/budget.shtml https://beta.fec.gov/about/reports-about-fec
 rewrite ^/pages/budget/budget.shtml https://beta.fec.gov/about/reports-about-fec/strategy-budget-and-performance/ redirect;
 rewrite ^/info/filing.shtml https://beta.fec.gov/candidate-and-committee-services/ redirect;
 rewrite ^/info/filing.shtml https://beta.fec.gov/candidate-and-committee-services/ redirect;
-rewrite ^/info/report_dates.shtml https://beta.fec.gov/candidate-and-committee-services/reporting-dates/ redirect;
+rewrite ^/info/report_dates.shtml https://beta.fec.gov/help-candidates-and-committees/dates-and-deadlines/ redirect;
 rewrite ^/pages/contact.shtml https://beta.fec.gov/contact-us/ redirect;
 rewrite ^/pages/brochures/ao.shtml https://beta.fec.gov/data/legal/advisory-opinions/ redirect;
 rewrite ^/law/law.shtml https://beta.fec.gov/legal-resources/ redirect;
@@ -56,8 +56,6 @@ rewrite ^/press/index.shtml https://beta.fec.gov/press/ redirect;
 rewrite ^/press/press_contacts.shtml https://beta.fec.gov/press/#contact redirect;
 rewrite ^/press/resources_for_reporters.shtml https://beta.fec.gov/press/resources-journalists/ redirect;
 rewrite ^/law/cfr/cfr.shtml https://beta.fec.gov/regulations redirect;
-rewrite ^/pages/fecrecord/fecrecord.shtml https://beta.fec.gov/updates/?update_type=fec-record redirect;
-rewrite ^/pages/record.shtml https://beta.fec.gov/updates/?update_type=fec-record redirect;
 rewrite ^/agenda/meetings.shtml https://beta.fec.gov/updates/?update_type=meetings redirect;
 rewrite ^/agenda/agendas.shtml https://beta.fec.gov/updates/?update_type=meetings redirect;
 rewrite ^/audio/audio.shtml https://beta.fec.gov/updates/?update_type=meetings redirect;


### PR DESCRIPTION
Removed redirect for record articles so that users can access articles on transition prior to 2004. Fixed broken redirect for reporting dates.