### PR TITLE
Agenda page redirects and upload limits

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -28,7 +28,7 @@ http {
     listen <%= ENV["PORT"] %>;
     server_name localhost;
 
-	client_max_body_size 40M; #increase upload size limit
+	client_max_body_size 60M; #increase upload size limit
 	include <%= ENV["APP_ROOT"] %>/public/redirects-www.conf;
 
     <% if File.exists?(auth_file = File.join(ENV["APP_ROOT"], "nginx/conf/.htpasswd")) %>

--- a/redirects-www.conf
+++ b/redirects-www.conf
@@ -1,6 +1,6 @@
 # rewrite rules
 
-rewrite ^/af/pay.shtml /legal-resources/enforcement/administrative-fines/#pay redirect;
+rewrite ^/af/pay.shtml /legal-resources/enforcement/administrative-fines/#paying-a-fine redirect;
 rewrite ^/pindex.shtml http://classic.fec.gov/pindex.shtml redirect;
 rewrite ^/portal/graphic_presentation.shtml http://classic.fec.gov/portal/graphic_presentation.shtml redirect;
 rewrite ^/disclosurep/pnational.do http://classic.fec.gov/disclosurep/pnational.do redirect;

--- a/redirects-www.conf
+++ b/redirects-www.conf
@@ -15,6 +15,16 @@ rewrite ^/portal/download.shtml http://classic.fec.gov/portal/download.shtml red
 rewrite ^/data/DataCatalog.do http://classic.fec.gov/data/DataCatalog.do redirect;
 rewrite ^/agenda/meetings.shtml /updates/?update_type=meetings redirect;
 rewrite ^/agenda/agendas.shtml /updates/?update_type=meetings redirect;
+rewrite ^/agenda/2016/agendaaudithearing20161206.shtml https://www.fec.gov/updates/december-6-2016-audit-hearing-open-meeting/ redirect;
+rewrite ^/agenda/2015/agendaaudithearing20150506.shtml https://www.fec.gov/updates/rescheduled-to-wednesday-may-13-2015-at-1000-ammay-6-2015-audit-hearing-open-meeting/ redirect;
+rewrite ^/agenda/2014/agendaaudithearing20141120.shtml https://www.fec.gov/updates/november-20-2014-audit-hearing-open-meeting/ redirect;
+rewrite ^/agenda/2014/agendaaudithearing20140612.shtml https://www.fec.gov/updates/june-12-2014-audit-hearing-open-meeting/ redirect;
+rewrite ^/agenda/2014/agendaaudithearing20140423.shtml https://www.fec.gov/updates/april-23-2014audit-hearing-open-meeting/ redirect;
+rewrite ^/agenda/2012/agendaaudithearing20120823.shtml https://www.fec.gov/updates/august-23-2012-audit-hearing-open-meeting/ redirect;
+rewrite ^/agenda/2012/agendaaudithearing20120627.shtml https://www.fec.gov/updates/june-27-2012-open-meeting/ redirect;
+rewrite ^/agenda/2010/oral_hearing20100120.shtml https://www.fec.gov/updates/oral-hearing-postponed-open-meeting/ redirect;
+rewrite ^/agenda/2009/oral_hearing20091104.shtml https://www.fec.gov/updates/november-4-2009-open-meeting/ redirect;
+rewrite ^/agenda/2015/agenda_administrative_review_hearing20151102.shtml https://www.fec.gov/updates/november-2-2015-administrative-review-hearing-open-meeting/ redirect;
 rewrite ^/info/hearings.shtml https://transition.fec.gov/info/hearings.shtml redirect;
 rewrite ^/calendar/calendar.shtml http://classic.fec.gov/calendar/calendar.shtml redirect;
 rewrite ^/law/legalconsideration.shtml https://transition.fec.gov/law/legalconsideration.shtml redirect;
@@ -153,3 +163,57 @@ rewrite ^/agenda/([0-9]+)/documents/(.*) /resources/updates/agendas/$1/$2 redire
 rewrite ^/agenda/([0-9]+)/(.*).pdf /resources/updates/agendas/$1/$2.pdf redirect;
 rewrite ^/disclosure_data/(.*) http://classic.fec.gov/disclosure_data/$1 redirect;
 rewrite ^/finance/(.*) http://classic.fec.gov/finance/$1 redirect;
+
+# Captures single digit days padded with a 0. Ex: 01, 02, 03, etc. This will translate to non-padded day format. 
+rewrite "^/agenda/([0-9]{4})/agenda([0-9]{4})010([0-9]).*" https://www.fec.gov/updates/january-$3-$2-open-meeting/ redirect;
+rewrite "^/agenda/([0-9]{4})/agenda([0-9]{4})020([0-9]).*" https://www.fec.gov/updates/february-$3-$2-open-meeting/ redirect;
+rewrite "^/agenda/([0-9]{4})/agenda([0-9]{4})030([0-9]).*" https://www.fec.gov/updates/march-$3-$2-open-meeting/ redirect;
+rewrite "^/agenda/([0-9]{4})/agenda([0-9]{4})040([0-9]).*" https://www.fec.gov/updates/april-$3-$2-open-meeting/ redirect;
+rewrite "^/agenda/([0-9]{4})/agenda([0-9]{4})050([0-9]).*" https://www.fec.gov/updates/may-$3-$2-open-meeting/ redirect;
+rewrite "^/agenda/([0-9]{4})/agenda([0-9]{4})060([0-9]).*" https://www.fec.gov/updates/june-$3-$2-open-meeting/ redirect;
+rewrite "^/agenda/([0-9]{4})/agenda([0-9]{4})070([0-9]).*" https://www.fec.gov/updates/july-$3-$2-open-meeting/ redirect;
+rewrite "^/agenda/([0-9]{4})/agenda([0-9]{4})080([0-9]).*" https://www.fec.gov/updates/august-$3-$2-open-meeting/ redirect;
+rewrite "^/agenda/([0-9]{4})/agenda([0-9]{4})090([0-9]).*" https://www.fec.gov/updates/september-$3-$2-open-meeting/ redirect;
+rewrite "^/agenda/([0-9]{4})/agenda([0-9]{4})100([0-9]).*" https://www.fec.gov/updates/october-$3-$2-open-meeting/ redirect;
+rewrite "^/agenda/([0-9]{4})/agenda([0-9]{4})110([0-9]).*" https://www.fec.gov/updates/november-$3-$2-open-meeting/ redirect;
+rewrite "^/agenda/([0-9]{4})/agenda([0-9]{4})120([0-9]).*" https://www.fec.gov/updates/december-$3-$2-open-meeting/ redirect;
+rewrite "^/agenda/agendas([0-9]{4})/agenda([0-9]{4})010([0-9]).*" https://www.fec.gov/updates/january-$3-$2-open-meeting/ redirect;
+rewrite "^/agenda/agendas([0-9]{4})/agenda([0-9]{4})020([0-9]).*" https://www.fec.gov/updates/february-$3-$2-open-meeting/ redirect;
+rewrite "^/agenda/agendas([0-9]{4})/agenda([0-9]{4})030([0-9]).*" https://www.fec.gov/updates/march-$3-$2-open-meeting/ redirect;
+rewrite "^/agenda/agendas([0-9]{4})/agenda([0-9]{4})040([0-9]).*" https://www.fec.gov/updates/april-$3-$2-open-meeting/ redirect;
+rewrite "^/agenda/agendas([0-9]{4})/agenda([0-9]{4})050([0-9]).*" https://www.fec.gov/updates/may-$3-$2-open-meeting/ redirect;
+rewrite "^/agenda/agendas([0-9]{4})/agenda([0-9]{4})060([0-9]).*" https://www.fec.gov/updates/june-$3-$2-open-meeting/ redirect;
+rewrite "^/agenda/agendas([0-9]{4})/agenda([0-9]{4})070([0-9]).*" https://www.fec.gov/updates/july-$3-$2-open-meeting/ redirect;
+rewrite "^/agenda/agendas([0-9]{4})/agenda([0-9]{4})080([0-9]).*" https://www.fec.gov/updates/august-$3-$2-open-meeting/ redirect;
+rewrite "^/agenda/agendas([0-9]{4})/agenda([0-9]{4})090([0-9]).*" https://www.fec.gov/updates/september-$3-$2-open-meeting/ redirect;
+rewrite "^/agenda/agendas([0-9]{4})/agenda([0-9]{4})100([0-9]).*" https://www.fec.gov/updates/october-$3-$2-open-meeting/ redirect;
+rewrite "^/agenda/agendas([0-9]{4})/agenda([0-9]{4})110([0-9]).*" https://www.fec.gov/updates/november-$3-$2-open-meeting/ redirect;
+rewrite "^/agenda/agendas([0-9]{4})/agenda([0-9]{4})120([0-9]).*" https://www.fec.gov/updates/december-$3-$2-open-meeting/ redirect;
+
+# Captures all dates of format agenda/YYYY/agendaYYYYMMDD
+rewrite "^/agenda/([0-9]{4})/agenda([0-9]{4})01([0-9]{2}).*" https://www.fec.gov/updates/january-$3-$2-open-meeting/ redirect;
+rewrite "^/agenda/([0-9]{4})/agenda([0-9]{4})02([0-9]{2}).*" https://www.fec.gov/updates/february-$3-$2-open-meeting/ redirect;
+rewrite "^/agenda/([0-9]{4})/agenda([0-9]{4})03([0-9]{2}).*" https://www.fec.gov/updates/march-$3-$2-open-meeting/ redirect;
+rewrite "^/agenda/([0-9]{4})/agenda([0-9]{4})04([0-9]{2}).*" https://www.fec.gov/updates/april-$3-$2-open-meeting/ redirect;
+rewrite "^/agenda/([0-9]{4})/agenda([0-9]{4})05([0-9]{2}).*" https://www.fec.gov/updates/may-$3-$2-open-meeting/ redirect;
+rewrite "^/agenda/([0-9]{4})/agenda([0-9]{4})06([0-9]{2}).*" https://www.fec.gov/updates/june-$3-$2-open-meeting/ redirect;
+rewrite "^/agenda/([0-9]{4})/agenda([0-9]{4})07([0-9]{2}).*" https://www.fec.gov/updates/july-$3-$2-open-meeting/ redirect;
+rewrite "^/agenda/([0-9]{4})/agenda([0-9]{4})08([0-9]{2}).*" https://www.fec.gov/updates/august-$3-$2-open-meeting/ redirect;
+rewrite "^/agenda/([0-9]{4})/agenda([0-9]{4})09([0-9]{2}).*" https://www.fec.gov/updates/september-$3-$2-open-meeting/ redirect;
+rewrite "^/agenda/([0-9]{4})/agenda([0-9]{4})10([0-9]{2}).*" https://www.fec.gov/updates/october-$3-$2-open-meeting/ redirect;
+rewrite "^/agenda/([0-9]{4})/agenda([0-9]{4})11([0-9]{2}).*" https://www.fec.gov/updates/november-$3-$2-open-meeting/ redirect;
+rewrite "^/agenda/([0-9]{4})/agenda([0-9]{4})12([0-9]{2}).*" https://www.fec.gov/updates/december-$3-$2-open-meeting/ redirect;
+
+# Captures all dates of format agenda/agendasYYYY/agendaYYYYMMDD
+rewrite "^/agenda/agendas([0-9]{4})/agenda([0-9]{4})01([0-9]{2}).*" https://www.fec.gov/updates/january-$3-$2-open-meeting/ redirect;
+rewrite "^/agenda/agendas([0-9]{4})/agenda([0-9]{4})02([0-9]{2}).*" https://www.fec.gov/updates/february-$3-$2-open-meeting/ redirect;
+rewrite "^/agenda/agendas([0-9]{4})/agenda([0-9]{4})03([0-9]{2}).*" https://www.fec.gov/updates/march-$3-$2-open-meeting/ redirect;
+rewrite "^/agenda/agendas([0-9]{4})/agenda([0-9]{4})04([0-9]{2}).*" https://www.fec.gov/updates/april-$3-$2-open-meeting/ redirect;
+rewrite "^/agenda/agendas([0-9]{4})/agenda([0-9]{4})05([0-9]{2}).*" https://www.fec.gov/updates/may-$3-$2-open-meeting/ redirect;
+rewrite "^/agenda/agendas([0-9]{4})/agenda([0-9]{4})06([0-9]{2}).*" https://www.fec.gov/updates/june-$3-$2-open-meeting/ redirect;
+rewrite "^/agenda/agendas([0-9]{4})/agenda([0-9]{4})07([0-9]{2}).*" https://www.fec.gov/updates/july-$3-$2-open-meeting/ redirect;
+rewrite "^/agenda/agendas([0-9]{4})/agenda([0-9]{4})08([0-9]{2}).*" https://www.fec.gov/updates/august-$3-$2-open-meeting/ redirect;
+rewrite "^/agenda/agendas([0-9]{4})/agenda([0-9]{4})09([0-9]{2}).*" https://www.fec.gov/updates/september-$3-$2-open-meeting/ redirect;
+rewrite "^/agenda/agendas([0-9]{4})/agenda([0-9]{4})10([0-9]{2}).*" https://www.fec.gov/updates/october-$3-$2-open-meeting/ redirect;
+rewrite "^/agenda/agendas([0-9]{4})/agenda([0-9]{4})11([0-9]{2}).*" https://www.fec.gov/updates/november-$3-$2-open-meeting/ redirect;
+rewrite "^/agenda/agendas([0-9]{4})/agenda([0-9]{4})12([0-9]{2}).*" https://www.fec.gov/updates/december-$3-$2-open-meeting/ redirect;


### PR DESCRIPTION
Created regex redirects for all agenda pages. Also increased the upload limits for the client. This is necessary at times since we sometimes have large MP3 files.

This has been deployed to dev for testing and it seems to be working.