### PR TITLE
Added Legal and Download Bucket Routing

### DIFF
--- a/manifest_dev.yml
+++ b/manifest_dev.yml
@@ -14,3 +14,4 @@ env:
     }
   S3_BUCKET_URL: "https://cg-449d4df6-4b9e-4539-891f-363302ca5907.s3-us-gov-west-1.amazonaws.com"
   S3_TRANSITION_URL: "https://cg-9b32b324-4671-48ca-b13b-a37b742f7443.s3-website-us-gov-west-1.amazonaws.com"
+  S3_LEGAL_AND_DOWNLOADS_URL: https://cg-cc8e3d72-34c9-411d-b369-96c0ce6572fd.s3-us-gov-west-1.amazonaws.com"

--- a/manifest_dev.yml
+++ b/manifest_dev.yml
@@ -14,4 +14,4 @@ env:
     }
   S3_BUCKET_URL: "https://cg-449d4df6-4b9e-4539-891f-363302ca5907.s3-us-gov-west-1.amazonaws.com"
   S3_TRANSITION_URL: "https://cg-9b32b324-4671-48ca-b13b-a37b742f7443.s3-website-us-gov-west-1.amazonaws.com"
-  S3_LEGAL_AND_DOWNLOADS_URL: https://cg-cc8e3d72-34c9-411d-b369-96c0ce6572fd.s3-us-gov-west-1.amazonaws.com"
+  S3_LEGAL_AND_DOWNLOADS_URL: "https://cg-cc8e3d72-34c9-411d-b369-96c0ce6572fd.s3-us-gov-west-1.amazonaws.com"

--- a/manifest_prod.yml
+++ b/manifest_prod.yml
@@ -17,3 +17,4 @@ env:
     }
   S3_BUCKET_URL: "https://cg-47928592-406c-4536-8234-99b896e8d57d.s3-us-gov-west-1.amazonaws.com"
   S3_TRANSITION_URL: "http://cg-9b32b324-4671-48ca-b13b-a37b742f7443.s3-website-us-gov-west-1.amazonaws.com"
+  S3_LEGAL_AND_DOWNLOADS_URL: "https://cg-519a459a-0ea3-42c2-b7bc-fa1143481f74.s3-us-gov-west-1.amazonaws.com"

--- a/manifest_stage.yml
+++ b/manifest_stage.yml
@@ -11,3 +11,4 @@ env:
       "/regulations": "https://fec-stage-eregs.app.cloud.gov"
     }
   S3_BUCKET_URL: "https://cg-ca811ea5-b3e6-4792-ac55-2edf11f151ca.s3-us-gov-west-1.amazonaws.com"
+  S3_LEGAL_AND_DOWNLOADS_URL: "https://cg-d3527d7d-0344-45b5-aab6-5a39d2aa409f.s3-us-gov-west-1.amazonaws.com"

--- a/nginx.conf
+++ b/nginx.conf
@@ -56,6 +56,12 @@ http {
       proxy_pass_request_headers off;
       proxy_pass <%= ENV["S3_BUCKET_URL"] %>/$1;
     }
+	
+    location ~ /files/(.*) {
+      resolver 8.8.8.8;
+      proxy_pass_request_headers off;
+      proxy_pass <%= ENV["S3_LEGAL_AND_DOWNLOADS_URL"] %>/$1;
+    }
   }
   server {
     listen <%= ENV["PORT"] %>;


### PR DESCRIPTION
This change allows for s3 buckets to route through the `https://root_domain/files/` path. This includes legal documents as well as downloads:

**Example Legal Doc Path:**
https://fec-dev-proxy.app.cloud.gov/files/legal/aos/83238.pdf

**Example Downloads Path:**
https://fec-dev-proxy.app.cloud.gov/files/47a21f26da800501a1d66a9356251254673d1f0fcfb557f4ae589ea7.zip?Signature=TKjcEErMTfDLk5SgdsCGhAIAGrk%3D&Expires=1498507164&AWSAccessKeyId=AKIAKJRR72G36QMQSGNQ