### PR TITLE
Redirect beta domain

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -59,6 +59,11 @@ http {
   }
   server {
     listen <%= ENV["PORT"] %>;
+    server_name beta.fec.gov;
+	  rewrite ^/(.*)$ https://www.fec.gov/$1 permanent;
+  }
+  server {
+    listen <%= ENV["PORT"] %>;
     server_name transition.fec.gov;
 	include <%= ENV["APP_ROOT"] %>/public/redirects-transition.conf;
     location / {
@@ -68,12 +73,6 @@ http {
 	proxy_hide_header      x-amz-request-id;
 	proxy_hide_header      x-amz-meta-s3cmd-attrs;
     proxy_pass <%= ENV["S3_TRANSITION_URL"] %>$uri;
-    }
-	
-    server {
-      listen <%= ENV["PORT"] %>;
-      server_name fec-dev-proxy.app.cloud.gov;
-  	  rewrite ^/$ http://www.fec.gov redirect;
     }
   }
 }

--- a/nginx.conf
+++ b/nginx.conf
@@ -68,11 +68,12 @@ http {
 	include <%= ENV["APP_ROOT"] %>/public/redirects-transition.conf;
     location / {
       resolver 8.8.8.8;
-    error_page 404 error.html;
-	proxy_hide_header      x-amz-id-2;
-	proxy_hide_header      x-amz-request-id;
-	proxy_hide_header      x-amz-meta-s3cmd-attrs;
-    proxy_pass <%= ENV["S3_TRANSITION_URL"] %>$uri;
+      error_page 404 error.html;
+	  proxy_hide_header      x-amz-id-2;
+	  proxy_hide_header      x-amz-request-id;
+	  proxy_hide_header      x-amz-meta-s3cmd-attrs;
+      proxy_pass <%= ENV["S3_TRANSITION_URL"] %>$uri;
+	  add_header X-Frame-Options "SAMEORIGIN";
     }
   }
 }

--- a/nginx.conf
+++ b/nginx.conf
@@ -69,5 +69,11 @@ http {
 	proxy_hide_header      x-amz-meta-s3cmd-attrs;
     proxy_pass <%= ENV["S3_TRANSITION_URL"] %>$uri;
     }
+	
+    server {
+      listen <%= ENV["PORT"] %>;
+      server_name fec-dev-proxy.app.cloud.gov;
+  	  rewrite ^/$ http://www.fec.gov redirect;
+    }
   }
 }


### PR DESCRIPTION
This permanently redirects the beta.fec.gov domain to www.fec.gov. Also added an x-frame-option same origin for the transition.fec.gov domain. This is needed so that iframes can be displayed on the transition domain.