### PR TITLE
redirecting press release PDF URLs up to 1998

### DIFF
--- a/redirects-www.conf
+++ b/redirects-www.conf
@@ -86,7 +86,6 @@ rewrite ^/press/weekly_digests.shtml /updates/?update_type=weekly-digest redirec
 rewrite ^/press/campaign_finance_statistics.shtml https://transition.fec.gov/press/campaign_finance_statistics.shtml redirect;
 rewrite ^/press/resources_for_reporters.shtml /press/resources-journalists/ redirect;
 rewrite ^/press/press_contacts.shtml /press/#contact redirect;
-rewrite ^/press/archive/(.*) /resources/news_releases/$1 redirect;
 rewrite ^/ans/answers.shtml https://transition.fec.gov/ans/answers.shtml redirect;
 rewrite ^/ans/answers_general.shtml https://transition.fec.gov/ans/answers_general.shtml redirect;
 rewrite ^/ans/answers_disclosure.shtml https://transition.fec.gov/ans/answers_disclosure.shtml redirect;
@@ -164,6 +163,7 @@ rewrite ^/agenda/([0-9]+)/documents/(.*) /resources/updates/agendas/$1/$2 redire
 rewrite ^/agenda/([0-9]+)/(.*).pdf /resources/updates/agendas/$1/$2.pdf redirect;
 rewrite ^/disclosure_data/(.*) http://classic.fec.gov/disclosure_data/$1 redirect;
 rewrite ^/finance/(.*) http://classic.fec.gov/finance/$1 redirect;
+rewrite ^/press/archive/(.*) /resources/news_releases/$1 redirect;
 
 # Captures single digit days padded with a 0. Ex: 01, 02, 03, etc. This will translate to non-padded day format.
 rewrite "^/agenda/([0-9]{4})/agenda([0-9]{4})010([0-9]).*" https://www.fec.gov/updates/january-$3-$2-open-meeting/ redirect;

--- a/redirects-www.conf
+++ b/redirects-www.conf
@@ -86,6 +86,7 @@ rewrite ^/press/weekly_digests.shtml /updates/?update_type=weekly-digest redirec
 rewrite ^/press/campaign_finance_statistics.shtml https://transition.fec.gov/press/campaign_finance_statistics.shtml redirect;
 rewrite ^/press/resources_for_reporters.shtml /press/resources-journalists/ redirect;
 rewrite ^/press/press_contacts.shtml /press/#contact redirect;
+rewrite ^/press/archive/(.*) /resources/news_releases/$1 redirect;
 rewrite ^/ans/answers.shtml https://transition.fec.gov/ans/answers.shtml redirect;
 rewrite ^/ans/answers_general.shtml https://transition.fec.gov/ans/answers_general.shtml redirect;
 rewrite ^/ans/answers_disclosure.shtml https://transition.fec.gov/ans/answers_disclosure.shtml redirect;
@@ -164,7 +165,7 @@ rewrite ^/agenda/([0-9]+)/(.*).pdf /resources/updates/agendas/$1/$2.pdf redirect
 rewrite ^/disclosure_data/(.*) http://classic.fec.gov/disclosure_data/$1 redirect;
 rewrite ^/finance/(.*) http://classic.fec.gov/finance/$1 redirect;
 
-# Captures single digit days padded with a 0. Ex: 01, 02, 03, etc. This will translate to non-padded day format. 
+# Captures single digit days padded with a 0. Ex: 01, 02, 03, etc. This will translate to non-padded day format.
 rewrite "^/agenda/([0-9]{4})/agenda([0-9]{4})010([0-9]).*" https://www.fec.gov/updates/january-$3-$2-open-meeting/ redirect;
 rewrite "^/agenda/([0-9]{4})/agenda([0-9]{4})020([0-9]).*" https://www.fec.gov/updates/february-$3-$2-open-meeting/ redirect;
 rewrite "^/agenda/([0-9]{4})/agenda([0-9]{4})030([0-9]).*" https://www.fec.gov/updates/march-$3-$2-open-meeting/ redirect;


### PR DESCRIPTION
Tested on my local NGINX Server by adding the redirect to nginx.conf:
![redirect_gif](https://user-images.githubusercontent.com/5572856/28806882-6313cc86-7640-11e7-9079-cc923c4dc5d5.gif)
