### PR TITLE
redirect BCRA pages

### DIFF
--- a/redirects-transition.conf
+++ b/redirects-transition.conf
@@ -50,6 +50,11 @@ rewrite ^/press/weekly_digests.shtml https://www.fec.gov/updates/?update_type=we
 rewrite ^/info/compliance.shtml /index.html redirect;
 rewrite ^/press/foia.shtml https://www.fec.gov/freedom-information-act/ redirect;
 rewrite ^/rad/index.shtml /rad/index.html redirect;
+rewrite ^/pages/bcra/bcra_update.shtml https://www.fec.gov/legal-resources/legislation/ redirect;
+rewrite ^/pages/bcra/major_resources_bcra.shtml https://www.fec.gov/legal-resources/ redirect;
+rewrite ^/pages/bcra/litigation.shtml https://www.fec.gov/legal-resources/court-cases/ redirect;
+rewrite ^/pages/bcra/aos_bcra.shtml https://www.fec.gov/data/legal/search/advisory-opinions/?type=advisory_opinions&search=BCRA&q=BCRA&ao_category=F redirect;
+rewrite ^/pages/bcra/rulemakings/rulemakings_bcra.shtml https://www.fec.gov/legal-resources/regulations/ redirect;
 rewrite ^/pdf/nprm/(.*) https://www.fec.gov/resources/legal-resources/rulemakings/nprm/$1 redirect;
 rewrite ^/agenda/([0-9]+)/documents/(.*) https://www.fec.gov/resources/updates/agendas/$1/$2 redirect;
 rewrite ^/agenda/([0-9]+)/(.*).pdf https://www.fec.gov/resources/updates/agendas/$1/$2.pdf redirect;

--- a/redirects-www.conf
+++ b/redirects-www.conf
@@ -55,7 +55,11 @@ rewrite ^/info/ElectionDate/ https://transition.fec.gov/info/ElectionDate/ redir
 rewrite ^/info/publications.shtml https://transition.fec.gov/info/publications.shtml redirect;
 rewrite ^/pages/fecrecord/fecrecord.shtml /updates/?update_type=fec-record redirect;
 rewrite ^/pages/record.shtml /updates/?update_type=fec-record redirect;
-rewrite ^/pages/bcra/bcra_update.shtml https://transition.fec.gov/pages/bcra/bcra_update.shtml redirect;
+rewrite ^/pages/bcra/bcra_update.shtml /legal-resources/legislation/ redirect;
+rewrite ^/pages/bcra/major_resources_bcra.shtml /legal-resources/ redirect;
+rewrite ^/pages/bcra/litigation.shtml /legal-resources/court-cases/ redirect;
+rewrite ^/pages/bcra/aos_bcra.shtml /data/legal/search/advisory-opinions/?type=advisory_opinions&search=BCRA&q=BCRA&ao_category=F redirect;
+rewrite ^/pages/bcra/rulemakings/rulemakings_bcra.shtml /legal-resources/regulations/ redirect;
 rewrite ^/info/outreach.shtml https://transition.fec.gov/info/outreach.shtml redirect;
 rewrite ^/info/elearning.shtml https://transition.fec.gov/info/elearning.shtml redirect;
 rewrite ^/info/outreach.shtml https://transition.fec.gov/info/outreach.shtml redirect;


### PR DESCRIPTION
Lines 53 through 57 of redirects-transition.conf have the BCRA redirects, let me know of they need to go in another location