### PR TITLE
Hotfix/tables redirects

### DIFF
--- a/redirects-www.conf
+++ b/redirects-www.conf
@@ -109,6 +109,8 @@ rewrite ^/info/FECWebinars.shtml https://transition.fec.gov/info/FECWebinars.sht
 rewrite ^/info/roundtable_materials/workshopmaterials.shtml https://transition.fec.gov/info/roundtable_materials/workshopmaterials.shtml redirect;
 rewrite ^/info/compliance.shtml https://transition.fec.gov/index.html redirect;
 rewrite ^/press/foia.shtml /freedom-information-act/ redirect;
+rewrite ^/press/bkgnd/presidential_fund.shtml https://transition.fec.gov/press/bkgnd/presidential_fund.shtml redirect;
+rewrite ^/press/bkgnd/EnforcementStatistics.shtml https://transition.fec.gov/press/bkgnd/EnforcementStatistics.shtml
 rewrite ^/general/library.shtml https://transition.fec.gov/general/library.shtml redirect;
 rewrite ^/info/contriblimitschart1718.pdf https://transition.fec.gov/info/contriblimitschart1718.pdf redirect;
 rewrite ^/members/walther/walther.shtml /about/leadership-and-structure/steven-t-walther/ redirect;

--- a/redirects-www.conf
+++ b/redirects-www.conf
@@ -110,7 +110,7 @@ rewrite ^/info/roundtable_materials/workshopmaterials.shtml https://transition.f
 rewrite ^/info/compliance.shtml https://transition.fec.gov/index.html redirect;
 rewrite ^/press/foia.shtml /freedom-information-act/ redirect;
 rewrite ^/press/bkgnd/presidential_fund.shtml https://transition.fec.gov/press/bkgnd/presidential_fund.shtml redirect;
-rewrite ^/press/bkgnd/EnforcementStatistics.shtml https://transition.fec.gov/press/bkgnd/EnforcementStatistics.shtml
+rewrite ^/press/bkgnd/EnforcementStatistics.shtml https://transition.fec.gov/press/bkgnd/EnforcementStatistics.shtml redirect;
 rewrite ^/general/library.shtml https://transition.fec.gov/general/library.shtml redirect;
 rewrite ^/info/contriblimitschart1718.pdf https://transition.fec.gov/info/contriblimitschart1718.pdf redirect;
 rewrite ^/members/walther/walther.shtml /about/leadership-and-structure/steven-t-walther/ redirect;

--- a/redirects-www.conf
+++ b/redirects-www.conf
@@ -109,8 +109,6 @@ rewrite ^/info/FECWebinars.shtml https://transition.fec.gov/info/FECWebinars.sht
 rewrite ^/info/roundtable_materials/workshopmaterials.shtml https://transition.fec.gov/info/roundtable_materials/workshopmaterials.shtml redirect;
 rewrite ^/info/compliance.shtml https://transition.fec.gov/index.html redirect;
 rewrite ^/press/foia.shtml /freedom-information-act/ redirect;
-rewrite ^/press/bkgnd/presidential_fund.shtml https://transition.fec.gov/press/bkgnd/presidential_fund.shtml redirect;
-rewrite ^/press/bkgnd/EnforcementStatistics.shtml https://transition.fec.gov/press/bkgnd/EnforcementStatistics.shtml
 rewrite ^/general/library.shtml https://transition.fec.gov/general/library.shtml redirect;
 rewrite ^/info/contriblimitschart1718.pdf https://transition.fec.gov/info/contriblimitschart1718.pdf redirect;
 rewrite ^/members/walther/walther.shtml /about/leadership-and-structure/steven-t-walther/ redirect;


### PR DESCRIPTION
Lines 111 and 112 of redirects-www.conf:
rewrite ^/press/bkgnd/presidential_fund.shtml https://transition.fec.gov/press/bkgnd/presidential_fund.shtml redirect;

rewrite ^/press/bkgnd/EnforcementStatistics.shtml https://transition.fec.gov/press/bkgnd/EnforcementStatistics.shtml redirect;