### PR TITLE
Added redirects for incorrect AO urls

### DIFF
--- a/redirects-www.conf
+++ b/redirects-www.conf
@@ -10,6 +10,8 @@ rewrite ^/disclosureie/ienational.do http://classic.fec.gov/disclosureie/ienatio
 rewrite ^/disclosureie/ienational.do?candOffice=S http://classic.fec.gov/disclosureie/ienational.do?candOffice=S redirect;
 rewrite ^/disclosure/pacSummary.do http://classic.fec.gov/disclosure/pacSummary.do redirect;
 rewrite ^/portal/searchable.shtml http://classic.fec.gov/portal/searchable.shtml redirect;
+rewrite ^/data/legal/search/advisory_opinions /data/legal/search/advisory-opinions/ redirect;
+rewrite ^/data/legal/advisory_opinions /data/legal/advisory-opinions/ redirect;
 rewrite ^/data/DataCatalog.do http://classic.fec.gov/data/DataCatalog.do redirect;
 rewrite ^/portal/download.shtml http://classic.fec.gov/portal/download.shtml redirect;
 rewrite ^/data/DataCatalog.do http://classic.fec.gov/data/DataCatalog.do redirect;


### PR DESCRIPTION
There were 2 AO URLs that were accidentally added during the web-app and cms merge. This redirects the bad URL to the correct one.