### PR TITLE
Redirect FEC forms page

### DIFF
--- a/redirects-transition.conf
+++ b/redirects-transition.conf
@@ -23,7 +23,7 @@ rewrite ^/portal/graphic_presentation.shtml http://classic.fec.gov/portal/graphi
 rewrite ^/portal/searchable.shtml http://classic.fec.gov/portal/searchable.shtml redirect;
 rewrite ^/privacy.shtml https://github.com/fecgov/policy/blob/master/privacy_policy_README.md redirect;
 rewrite ^/info/filing.shtml https://www.fec.gov/help-candidates-and-committees/ redirect;
-rewrite ^/info/forms.shtml /help-candidates-and-committees/forms/ redirect;
+rewrite ^/info/forms.shtml https://www.fec.gov/help-candidates-and-committees/forms/ redirect;
 rewrite ^/about.shtml https://www.fec.gov/about/ redirect;
 rewrite ^/working.shtml https://www.fec.gov/about/#working-with-the-fec redirect;
 rewrite ^/pages/jobs/jobs.shtml https://www.fec.gov/about/careers/ redirect;

--- a/redirects-transition.conf
+++ b/redirects-transition.conf
@@ -23,6 +23,7 @@ rewrite ^/portal/graphic_presentation.shtml http://classic.fec.gov/portal/graphi
 rewrite ^/portal/searchable.shtml http://classic.fec.gov/portal/searchable.shtml redirect;
 rewrite ^/privacy.shtml https://github.com/fecgov/policy/blob/master/privacy_policy_README.md redirect;
 rewrite ^/info/filing.shtml https://www.fec.gov/help-candidates-and-committees/ redirect;
+rewrite ^/info/forms.shtml /help-candidates-and-committees/forms/ redirect;
 rewrite ^/about.shtml https://www.fec.gov/about/ redirect;
 rewrite ^/working.shtml https://www.fec.gov/about/#working-with-the-fec redirect;
 rewrite ^/pages/jobs/jobs.shtml https://www.fec.gov/about/careers/ redirect;

--- a/redirects-www.conf
+++ b/redirects-www.conf
@@ -54,7 +54,7 @@ rewrite ^/efiling /help-candidates-and-committees/filing-reports/electronic-fili
 rewrite ^/support /help-candidates-and-committees/filing-reports/electronic-filing/ redirect;
 rewrite ^/elecfil/updatelist.shtml https://transition.fec.gov/elecfil/updatelist.html redirect;
 rewrite ^/elecfil/updatelist.html https://transition.fec.gov/elecfil/updatelist.html redirect;
-rewrite ^/info/forms.shtml https://transition.fec.gov/info/forms.shtml redirect;
+rewrite ^/info/forms.shtml /help-candidates-and-committees/forms/ redirect;
 rewrite ^/info/filing.shtml /help-candidates-and-committees/ redirect;
 rewrite ^/info/ElectionDate/ https://transition.fec.gov/info/ElectionDate/ redirect;
 rewrite ^/info/publications.shtml https://transition.fec.gov/info/publications.shtml redirect;


### PR DESCRIPTION
Old forms page is retiring. URLs need to redirect to new page per this issue: https://github.com/18F/fec-cms/issues/1352