### PR TITLE
Redirects for pages linked from compliance map

### DIFF
--- a/redirects-transition.conf
+++ b/redirects-transition.conf
@@ -45,7 +45,7 @@ rewrite ^/pages/brochures/delegate.shtml https://www.fec.gov/updates/national-pa
 rewrite ^/ans/answers_compliance.shtml#embezzlement1 https://www.fec.gov/help-candidates-and-committees/keeping-records/misappropriated-funds/ redirect;
 rewrite ^/pages/brochures/foreign.shtml https://www.fec.gov/updates/foreign-nationals/ redirect;
 rewrite ^/pages/brochures/jointfundraising.shtml https://www.fec.gov/updates/joint-fundraising-2/ redirect;
-rewrite ^/pages/brochures/locparty.shtml https://www.fec.gov/help-candidates-and-committees/making-disbursements-political-party/definition-federal-election-activity-fea/ redirect;
+rewrite ^/pages/brochures/locparty.shtml https://www.fec.gov/help-candidates-and-committees/registering-political-party/information-local-party-committees-not-registered-fec/ redirect;
 rewrite ^/pages/brochures/electioneering.shtml https://www.fec.gov/help-candidates-and-committees/making-disbursements-ssf-or-connected-organization/making-electioneering-communications/ redirect;
 rewrite ^/pages/brochures/ssfvnonconnected.shtml https://www.fec.gov/help-candidates-and-committees/registering-pac/understanding-nonconnected-pacs/ redirect;
 rewrite ^/pages/brochures/TestingtheWaters.shtml https://www.fec.gov/updates/testing-the-waters-2017/ redirect;

--- a/redirects-transition.conf
+++ b/redirects-transition.conf
@@ -38,14 +38,15 @@ rewrite ^/info/report_dates.shtml https://www.fec.gov/help-candidates-and-commit
 rewrite ^/pages/contact.shtml https://www.fec.gov/contact-us/ redirect;
 rewrite ^/pages/brochures/ao.shtml https://www.fec.gov/legal-resources/advisory-opinions-process/ redirect;
 rewrite ^/pages/brochures/bestpractices.shtml https://www.fec.gov/updates/best-practices-committee-management/ redirect;
-rewrite ^/pages/brochures/indexp.shtml https://www.fec.gov/help-candidates-and-committees/making-disbursements-pac/ redirect;
+rewrite ^/pages/brochures/indexp.shtml https://www.fec.gov/help-candidates-and-committees/making-disbursements/coordinated-communications/ redirect;
 rewrite ^/pages/brochures/treas.shtml https://www.fec.gov/updates/committee-treasurers-2017-record/ redirect;
 rewrite ^/pages/brochures/committee_treasurers_brochure.pdf https://www.fec.gov/updates/committee-treasurers-2017-record/ redirect;
 rewrite ^/pages/brochures/delegate.shtml https://www.fec.gov/updates/national-party-convention-delegates-2/ redirect;
 rewrite ^/ans/answers_compliance.shtml#embezzlement1 https://www.fec.gov/help-candidates-and-committees/keeping-records/misappropriated-funds/ redirect;
 rewrite ^/pages/brochures/foreign.shtml https://www.fec.gov/updates/foreign-nationals/ redirect;
 rewrite ^/pages/brochures/jointfundraising.shtml https://www.fec.gov/updates/joint-fundraising-2/ redirect;
-rewrite ^/pages/brochures/locparty.shtml https://www.fec.gov/help-candidates-and-committees/registering-political-party/information-local-party-committees-not-registered-fec/ redirect;
+rewrite ^/pages/brochures/locparty.shtml https://www.fec.gov/help-candidates-and-committees/making-disbursements-political-party/definition-federal-election-activity-fea/ redirect;
+rewrite ^/pages/brochures/electioneering.shtml https://www.fec.gov/help-candidates-and-committees/making-disbursements-ssf-or-connected-organization/making-electioneering-communications/ redirect;
 rewrite ^/pages/brochures/ssfvnonconnected.shtml https://www.fec.gov/help-candidates-and-committees/registering-pac/understanding-nonconnected-pacs/ redirect;
 rewrite ^/pages/brochures/TestingtheWaters.shtml https://www.fec.gov/updates/testing-the-waters-2017/ redirect;
 rewrite ^/law/law.shtml https://www.fec.gov/legal-resources/ redirect;


### PR DESCRIPTION
Received request from information division to update links referenced in compliance map with the following updated links:

Coordination Periods should link to
 
https://www.fec.gov/help-candidates-and-committees/making-disbursements/coordinated-communications/
 
Federal Election Activity Periods should link to  (ONLY ON COMPLIANCE MAP). Need to make a separate change to the link on the compliance map for FEA
 
https://www.fec.gov/help-candidates-and-committees/making-disbursements-political-party/definition-federal-election-activity-fea/
 
Electioneering Communication Periods should link to
 
https://www.fec.gov/help-candidates-and-committees/making-disbursements-ssf-or-connected-organization/making-electioneering-communications/